### PR TITLE
Pre-aggregate features to optimize query

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Adds spatial methods to a model.
 
     CREATE TABLE features (
         id integer NOT NULL,
+        type character varying(255),
         spatial_model_type character varying(255),
         spatial_model_id integer,
         name character varying(255),

--- a/app/models/abstract_feature.rb
+++ b/app/models/abstract_feature.rb
@@ -1,0 +1,167 @@
+class AbstractFeature < ActiveRecord::Base
+  self.table_name = 'features'
+
+  class_attribute :lowres_simplification
+  self.lowres_simplification = 2 # Threshold in meters
+
+  belongs_to :spatial_model, :polymorphic => :true, :autosave => false
+
+  attr_writer :make_valid
+
+  FEATURE_TYPES = %w(polygon point line)
+
+  before_validation :sanitize_feature_type
+  validates_presence_of :geog
+  validate :validate_geometry
+  before_save :sanitize
+  after_save :cache_derivatives
+
+  def self.cache_key
+    "#{maximum(:id)}-#{count}"
+  end
+
+  def self.with_metadata(k, v)
+    if k.present? && v.present?
+      where('metadata->? = ?', k, v)
+    else
+      all
+    end
+  end
+
+  def self.polygons
+    where(:feature_type => 'polygon')
+  end
+
+  def self.lines
+    where(:feature_type => 'line')
+  end
+
+  def self.points
+    where(:feature_type => 'point')
+  end
+
+  def self.area_in_square_meters(geom = 'geom_lowres')
+    current_scope = all.polygons
+    unscoped { connection.select_value(select("ST_Area(ST_Union(#{geom}))").from(current_scope, :features)).to_f }
+  end
+
+  def self.total_intersection_area_in_square_meters(other_features, geom = 'geom_lowres')
+    scope = unscope(:select).select("ST_Union(#{geom}) AS geom").polygons
+    other_scope = other_features.polygons
+
+    query = base_class.unscoped.select('ST_Area(ST_Intersection(ST_Union(features.geom), ST_Union(other_features.geom)))')
+                    .from(scope, "features")
+                    .joins("INNER JOIN (#{other_scope.to_sql}) AS other_features ON ST_Intersects(features.geom, other_features.geom)")
+    return connection.select_value(query).to_f
+  end
+
+  def self.intersecting(other)
+    join_other_features(other).where('ST_Intersects(features.geom_lowres, other_features.geom_lowres)').uniq
+  end
+
+  def self.invalid(column = 'geog::geometry')
+    select("features.*, ST_IsValidReason(#{column}) AS invalid_geometry_message").where.not("ST_IsValid(#{column})")
+  end
+
+  def self.valid
+    where('ST_IsValid(geog::geometry)')
+  end
+
+  def envelope(buffer_in_meters = 0)
+    envelope_json = JSON.parse(self.class.select("ST_AsGeoJSON(ST_Envelope(ST_Buffer(features.geog, #{buffer_in_meters})::geometry)) AS result").where(:id => id).first.result)
+    envelope_json = envelope_json["coordinates"].first
+
+    raise "Can't calculate envelope for Feature #{self.id}" if envelope_json.blank?
+
+    return envelope_json.values_at(0,2)
+  end
+
+  def self.cache_derivatives(options = {})
+    update_all <<-SQL.squish
+      geom         = ST_Transform(geog::geometry, #{detect_srid('geom')}),
+      north        = ST_YMax(geog::geometry),
+      east         = ST_XMax(geog::geometry),
+      south        = ST_YMin(geog::geometry),
+      west         = ST_XMin(geog::geometry),
+      area         = ST_Area(geog),
+      centroid     = ST_PointOnSurface(geog::geometry)
+    SQL
+
+    invalid('geom').update_all <<-SQL.squish
+      geom         = ST_Buffer(geom, 0)
+    SQL
+
+    update_all <<-SQL.squish
+      geom_lowres  = ST_SimplifyPreserveTopology(geom, #{options.fetch(:lowres_simplification, lowres_simplification)})
+    SQL
+
+    invalid('geom_lowres').update_all <<-SQL.squish
+      geom_lowres  = ST_Buffer(geom_lowres, 0)
+    SQL
+  end
+
+  def feature_bounds
+    {n: north, e: east, s: south, w: west}
+  end
+
+  def cache_derivatives(*args)
+    self.class.where(:id => self.id).cache_derivatives(*args)
+  end
+
+  def kml(options = {})
+    geometry = options[:lowres] ? kml_lowres : super()
+    geometry = "<MultiGeometry>#{geometry}#{kml_centroid}</MultiGeometry>" if options[:centroid]
+    return geometry
+  end
+
+  def make_valid?
+    @make_valid
+  end
+
+  private
+
+  def make_valid
+    self.geog = ActiveRecord::Base.connection.select_value("SELECT ST_Buffer('#{sanitize}', 0)")
+  end
+
+  # Use ST_Force2D to discard z-coordinates that cause failures later in the process
+  def sanitize
+    self.geog = ActiveRecord::Base.connection.select_value("SELECT ST_Force2D('#{geog}')")
+  end
+
+  SRID_CACHE = {}
+  def self.detect_srid(column_name)
+    SRID_CACHE[column_name] ||= connection.select_value("SELECT Find_SRID('public', '#{table_name}', '#{column_name}')")
+  end
+
+  def self.join_other_features(other)
+    joins('INNER JOIN features AS other_features ON true').where(:other_features => {:id => other})
+  end
+
+  def validate_geometry
+    return unless geog?
+
+    error = geometry_validation_message
+    if error && make_valid?
+      make_valid
+      self.make_valid = false
+      validate_geometry
+    elsif error
+      errors.add :geog, error
+    end
+  end
+
+  def geometry_validation_message
+    klass = self.class.base_class # Use the base class because we don't want to have to include a type column in our select
+    error = klass.connection.select_one(klass.unscoped.invalid.from("(SELECT '#{sanitize_input_for_sql(self.geog)}'::geometry AS geog) #{klass.table_name}"))
+    return error.fetch('invalid_geometry_message') if error
+  end
+
+  def sanitize_feature_type
+    self.feature_type = FEATURE_TYPES.find {|type| self.feature_type.to_s.strip.downcase.include?(type) }
+  end
+
+  def sanitize_input_for_sql(input)
+    self.class.send(:sanitize_sql_for_conditions, input)
+  end
+end

--- a/app/models/aggregate_feature.rb
+++ b/app/models/aggregate_feature.rb
@@ -1,0 +1,17 @@
+require_dependency SpatialFeatures::Engine.root.join('app/models/abstract_feature')
+
+class AggregateFeature < AbstractFeature
+  has_many :features, lambda { |aggregate| where(:spatial_model_type => aggregate.spatial_model_type) }, :foreign_key => :spatial_model_id, :primary_key => :spatial_model_id
+
+  # Aggregate the features for the spatial model into a single feature
+  def refresh
+    self.geog = ActiveRecord::Base.connection.select_value <<~SQL
+      SELECT ST_Collect(ARRAY[
+        (#{features.select('ST_UNION(ST_CollectionExtract(geog::geometry, 1))').to_sql}),
+        (#{features.select('ST_UNION(ST_CollectionExtract(geog::geometry, 2))').to_sql}),
+        (#{features.select('ST_UNION(ST_CollectionExtract(geog::geometry, 3))').to_sql})
+      ])::geography
+    SQL
+    self.save!
+  end
+end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -9,11 +9,44 @@ class Feature < AbstractFeature
 
   validates_inclusion_of :feature_type, :in => FEATURE_TYPES
 
-  after_save :refresh_aggregate, if: :spatial_model_id
+  after_save :refresh_aggregate, if: :automatically_refresh_aggregate?
+
+  def self.defer_aggregate_refresh(&block)
+    start_at = Feature.maximum(:id).to_i + 1
+    output = without_aggregate_refresh(&block)
+
+    where(:id => start_at..Float::INFINITY).refresh_aggregates
+
+    return output
+  end
+
+  def self.without_aggregate_refresh
+    old = Feature.automatically_refresh_aggregate
+    Feature.automatically_refresh_aggregate = false
+    yield
+  ensure
+    Feature.automatically_refresh_aggregate = old
+  end
+
+  def self.refresh_aggregates
+    # Find one feature from each spatial model and trigger the aggregate feature refresh
+    ids = select('MAX(id)')
+            .where.not(:spatial_model_type => nil, :spatial_model_id => nil)
+            .group('spatial_model_type, spatial_model_id')
+
+    where(:id => ids).find_each(&:refresh_aggregate)
+  end
 
   def refresh_aggregate
     build_aggregate_feature unless aggregate_feature&.persisted?
     aggregate_feature.refresh
+  end
+
+  def automatically_refresh_aggregate?
+    # Check if there is a spatial model id because nothing prevents is from creating a Feature without one. Depending on
+    # how you assign a feature to a record, you may end up saving it before assigning it to a record, thereby leaving
+    # this field blank.
+    spatial_model_id? && automatically_refresh_aggregate
   end
 
   # Features are used for display so we also cache their KML representation

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,170 +1,28 @@
-class Feature < ActiveRecord::Base
-  belongs_to :spatial_model, :polymorphic => :true, :autosave => false
+class Feature < AbstractFeature
+  class_attribute :automatically_refresh_aggregate
+  self.automatically_refresh_aggregate = true
 
-  attr_writer :make_valid
+  class_attribute :lowres_precision
+  self.lowres_precision = 5
 
-  FEATURE_TYPES = %w(polygon point line)
+  has_one :aggregate_feature, lambda { |feature| where(:spatial_model_type => feature.spatial_model_type) }, :foreign_key => :spatial_model_id, :primary_key => :spatial_model_id
 
-  before_validation :sanitize_feature_type
-  validates_presence_of :geog
-  validate :validate_geometry
   validates_inclusion_of :feature_type, :in => FEATURE_TYPES
-  before_save :sanitize
-  after_save :cache_derivatives
 
-  def self.cache_key
-    "#{maximum(:id)}-#{count}"
+  after_save :refresh_aggregate, if: :spatial_model_id
+
+  def refresh_aggregate
+    build_aggregate_feature unless aggregate_feature&.persisted?
+    aggregate_feature.refresh
   end
 
-  def self.with_metadata(k, v)
-    if k.present? && v.present?
-      where('metadata->? = ?', k, v)
-    else
-      all
-    end
-  end
-
-  def self.polygons
-    where(:feature_type => 'polygon')
-  end
-
-  def self.lines
-    where(:feature_type => 'line')
-  end
-
-  def self.points
-    where(:feature_type => 'point')
-  end
-
-  def self.area_in_square_meters(geom = 'geom_lowres')
-    current_scope = all.polygons
-    unscoped { connection.select_value(select("ST_Area(ST_Union(#{geom}))").from(current_scope, :features)).to_f }
-  end
-
-  def self.total_intersection_area_in_square_meters(other_features, geom = 'geom_lowres')
-    scope = unscope(:select).select("ST_Union(#{geom}) AS geom").polygons
-    other_scope = other_features.polygons
-
-    query = unscoped.select('ST_Area(ST_Intersection(ST_Union(features.geom), ST_Union(other_features.geom)))')
-                    .from(scope, "features")
-                    .joins("INNER JOIN (#{other_scope.to_sql}) AS other_features ON ST_Intersects(features.geom, other_features.geom)")
-    return connection.select_value(query).to_f
-  end
-
-  def self.intersecting(other)
-    join_other_features(other).where('ST_Intersects(features.geom_lowres, other_features.geom_lowres)').uniq
-  end
-
-  def self.invalid(column = 'geog::geometry')
-    select("features.*, ST_IsValidReason(#{column}) AS invalid_geometry_message").where.not("ST_IsValid(#{column})")
-  end
-
-  def self.valid
-    where('ST_IsValid(geog::geometry)')
-  end
-
-  def envelope(buffer_in_meters = 0)
-    envelope_json = JSON.parse(self.class.select("ST_AsGeoJSON(ST_Envelope(ST_Buffer(features.geog, #{buffer_in_meters})::geometry)) AS result").where(:id => id).first.result)
-    envelope_json = envelope_json["coordinates"].first
-
-    raise "Can't calculate envelope for Feature #{self.id}" if envelope_json.blank?
-
-    return envelope_json.values_at(0,2)
-  end
-
+  # Features are used for display so we also cache their KML representation
   def self.cache_derivatives(options = {})
-    options.reverse_merge! :lowres_simplification => 2, :lowres_precision => 5
-
-    update_all <<-SQL.squish
-      geom         = ST_Transform(geog::geometry, #{detect_srid('geom')}),
-      north        = ST_YMax(geog::geometry),
-      east         = ST_XMax(geog::geometry),
-      south        = ST_YMin(geog::geometry),
-      west         = ST_XMin(geog::geometry),
-      area         = ST_Area(geog),
-      centroid     = ST_PointOnSurface(geog::geometry)
-    SQL
-
-    invalid('geom').update_all <<-SQL.squish
-      geom         = ST_Buffer(geom, 0)
-    SQL
-
-    update_all <<-SQL.squish
-      geom_lowres  = ST_SimplifyPreserveTopology(geom, #{options[:lowres_simplification]})
-    SQL
-
-    invalid('geom_lowres').update_all <<-SQL.squish
-      geom_lowres  = ST_Buffer(geom_lowres, 0)
-    SQL
-
+    super
     update_all <<-SQL.squish
       kml          = ST_AsKML(geog, 6),
-      kml_lowres   = ST_AsKML(geom_lowres, #{options[:lowres_precision]}),
+      kml_lowres   = ST_AsKML(geom_lowres, #{options.fetch(:lowres_precision, lowres_precision)}),
       kml_centroid = ST_AsKML(centroid)
     SQL
-  end
-
-  def feature_bounds
-    {n: north, e: east, s: south, w: west}
-  end
-
-  def cache_derivatives(*args)
-    self.class.where(:id => self.id).cache_derivatives(*args)
-  end
-
-  def kml(options = {})
-    geometry = options[:lowres] ? kml_lowres : super()
-    geometry = "<MultiGeometry>#{geometry}#{kml_centroid}</MultiGeometry>" if options[:centroid]
-    return geometry
-  end
-
-  def make_valid?
-    @make_valid
-  end
-
-  private
-
-  def make_valid
-    self.geog = ActiveRecord::Base.connection.select_value("SELECT ST_Buffer('#{sanitize}', 0)")
-  end
-
-  # Use ST_Force2D to discard z-coordinates that cause failures later in the process
-  def sanitize
-    self.geog = ActiveRecord::Base.connection.select_value("SELECT ST_Force2D('#{geog}')")
-  end
-
-  SRID_CACHE = {}
-  def self.detect_srid(column_name)
-    SRID_CACHE[column_name] ||= connection.select_value("SELECT Find_SRID('public', '#{table_name}', '#{column_name}')")
-  end
-
-  def self.join_other_features(other)
-    joins('INNER JOIN features AS other_features ON true').where(:other_features => {:id => other})
-  end
-
-  def validate_geometry
-    return unless geog?
-
-    error = geometry_validation_message
-    if error && make_valid?
-      make_valid
-      self.make_valid = false
-      validate_geometry
-    elsif error
-      errors.add :geog, error
-    end
-  end
-
-  def geometry_validation_message
-    error = self.class.connection.select_one(self.class.unscoped.invalid.from("(SELECT '#{sanitize_input_for_sql(self.geog)}'::geometry AS geog) #{self.class.table_name}"))
-    return error.fetch('invalid_geometry_message') if error
-  end
-
-  def sanitize_feature_type
-    self.feature_type = FEATURE_TYPES.find {|type| self.feature_type.to_s.strip.downcase.include?(type) }
-  end
-
-  def sanitize_input_for_sql(input)
-    self.class.send(:sanitize_sql_for_conditions, input)
   end
 end

--- a/lib/spatial_features/has_spatial_features/feature_import.rb
+++ b/lib/spatial_features/has_spatial_features/feature_import.rb
@@ -79,9 +79,11 @@ module SpatialFeatures
 
     def import_features(imports, skip_invalid)
       self.features.delete_all
-      valid, invalid = imports.flat_map(&:features).partition do |feature|
-        feature.spatial_model = self
-        feature.save
+      valid, invalid = Feature.defer_aggregate_refresh do
+        imports.flat_map(&:features).partition do |feature|
+          feature.spatial_model = self
+          feature.save
+        end
       end
 
       errors = imports.flat_map(&:errors)

--- a/spec/lib/spatial_features/has_spatial_features_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features_spec.rb
@@ -22,6 +22,10 @@ describe SpatialFeatures do
   end
 
   describe "::within_buffer" do
+    # Because our numbers are small in these tests, we lower the simplification threshold so it is not drastically
+    # reshaping geometry in our tests.
+    before { allow(AbstractFeature).to receive(:lowres_simplification).and_return(0) }
+
     TOLERANCE = 0.000001 # Because calculations are performed using projected geometry, there will be a slight inaccuracy
     new_dummy_class(:name => 'BufferedRecord')
     new_dummy_class(:name => 'Shape')
@@ -220,12 +224,12 @@ describe SpatialFeatures do
         expect(record.features.area(options)).to be_within(TOLERANCE).of(1)
       end
 
-      it 'returns the correct value for a multiple non-overlapping features' do
+      it 'returns the correct value for multiple non-overlapping features' do
         record = create_record_with_polygon(Shape, Rectangle.new(1, 1), Rectangle.new(1, 1, :x => 2))
         expect(record.features.area(options)).to be_within(TOLERANCE).of(2)
       end
 
-      it 'returns the correct value for a multiple overlapping features' do
+      it 'returns the correct value for multiple overlapping features' do
         record = create_record_with_polygon(Shape, Rectangle.new(1, 1), Rectangle.new(1, 1, :x => 0.5))
         expect(record.features.area(options)).to be_within(TOLERANCE).of(1.5)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.decimal :east
     t.decimal :south
     t.decimal :west
+    t.string :type
   end
 
   create_table :spatial_caches, :force => true do |t|


### PR DESCRIPTION
Spatial joins can be expensive because we end up unioning all the features for each record on-the-fly. This means we’re not able to take advantage of precalculated indices for intersection.

Instead, we maintain an aggregate feature for all the features on a spatial model and use that when joining, avoiding the need to `ST_Union` each spatial model’s features on each query.