### PR TITLE
Improved KML metadata handling

### DIFF
--- a/spec/lib/spatial_features/importers/kml_spec.rb
+++ b/spec/lib/spatial_features/importers/kml_spec.rb
@@ -22,6 +22,54 @@ describe SpatialFeatures::Importers::KML do
       it 'sets the feature metadata' do
         expect(subject.features).to all(have_attributes :metadata => be_present)
       end
+
+      it 'sets the feature metadata specifed in extended data' do
+        doc = Nokogiri::XML(data)
+        doc.css('Placemark').each do |placemark|
+          extended_data = doc.create_element('ExtendedData')
+          extended_data.add_child doc.create_element('SimpleData', 'value', :name => 'test')
+          placemark.add_child(extended_data)
+        end
+
+        data.replace doc.to_s
+
+        expect(subject.features).to all(have_attributes :metadata => include('test' => 'value'))
+      end
+
+      it 'sets the feature metadata specifed in CDATA double-nested table in the description' do
+        doc = Nokogiri::XML(data)
+        description = <<-HTML
+        <html>
+          <body>
+            <table>
+              <tr>
+                <td>A87325</td>
+              </tr>
+              <tr>
+                <td>
+                  <table>
+                    <tr>
+                      <td>test</td>
+                      <td>value</td>
+                    </tr>
+                  </table>
+                </td>
+              <tr>
+            </table>
+          </body>
+        </html>
+        HTML
+
+        doc.css('Placemark').each do |placemark|
+          node = doc.create_element('description')
+          node.add_child(doc.create_cdata description)
+          placemark.add_child(node)
+        end
+
+        data.replace doc.to_s
+
+        expect(subject.features).to all(have_attributes :metadata => include('test' => 'value'))
+      end
     end
   end
 end


### PR DESCRIPTION
KML now imports metadata from HTML tables and `ExtendedData` nodes.

**TODO**
- [x] Add Tests for metadata import