### PR TITLE
Skip introspecting columns when database tables don't exist yet

### DIFF
--- a/lib/spatial_features/has_spatial_features.rb
+++ b/lib/spatial_features/has_spatial_features.rb
@@ -88,12 +88,12 @@ module SpatialFeatures
 
     # Returns true if the model stores a hash of the features so we don't need to process the features if they haven't changed
     def has_spatial_features_hash?
-      column_names.include? 'features_hash'
+      owner_class_has_loaded_column?('features_hash')
     end
 
     # Returns true if the model stores a cache of the features area
     def has_features_area?
-      column_names.include? 'features_area'
+      owner_class_has_loaded_column?('features_area')
     end
 
     def area_in_square_meters
@@ -159,6 +159,12 @@ module SpatialFeatures
       scope = scope.where(:spatial_model_type => Utils.base_class_of(other).to_s)
       scope = scope.where(:spatial_model_id => other) unless Utils.class_of(other) == other
       return scope
+    end
+
+    def owner_class_has_loaded_column?(column_name)
+      return false unless connected?
+      return false unless table_exists?
+      column_names.include? column_name
     end
   end
 

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -88,4 +88,14 @@ describe Feature do
       expect(house.features_cache_key).to be_a(String)
     end
   end
+
+  describe 'has_spatial_features' do
+    it 'evaluates model without error when no database table exists' do
+      eval("class NoTable < ActiveRecord::Base; end")
+      klass = NoTable
+
+      klass.table_name = "some_table_that_does_not_exist"
+      expect(klass.has_spatial_features).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
The `with_stale_spatial_cache` scope is only defined when the model has a `features_hash` column.  We won't have any tables to inspect when we're running this code before the database is setup (e.g. CI).

We short-circuit to `false` which temporarily gives us a reduced feature set but prevents errors.

Fixes #10
See https://github.com/culturecode/stolo_connect/pull/770