### PR TITLE
Re-raise exceptions in update_features! as ImportError

### DIFF
--- a/lib/spatial_features/has_spatial_features/feature_import.rb
+++ b/lib/spatial_features/has_spatial_features/feature_import.rb
@@ -42,6 +42,13 @@ module SpatialFeatures
 
         return true
       end
+    rescue StandardError => e
+      if skip_invalid
+        Rails.logger.warn "Error updating #{self.class} #{self.id}. #{e.message}"
+        return nil
+      else
+        raise ImportError, e.message, e.backtrace
+      end
     end
 
     def update_features_cache_key(cache_key)

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -210,6 +210,24 @@ describe SpatialFeatures::FeatureImport do
       expect { subject.update_features! }.not_to change { subject.class.count }
     end
 
+    it "wraps exceptions in SpatialFeatures::ImportError" do
+      subject = new_dummy_class(:parent => FeatureImportMock) do
+        has_spatial_features :import => { :test_kml => :KMLFile }
+      end.new
+
+      expect(subject).to receive(:import_features).once.and_raise(StandardError)
+      expect { subject.update_features! }.to raise_error(SpatialFeatures::ImportError)
+    end
+
+    it "swallows exceptions when skip_invalid is true" do
+      subject = new_dummy_class(:parent => FeatureImportMock) do
+        has_spatial_features :import => { :test_kml => :KMLFile }
+      end.new
+
+      expect(subject).to receive(:import_features).once.and_raise(StandardError)
+      expect(subject.update_features!(:skip_invalid => true)).to be_nil
+    end
+
     describe 'spatial caching' do
       let(:other_class) { new_dummy_class }
       subject do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'active_record'
 require 'spatial_features'
 require 'pry'
 
+Rails.logger = Logger.new(STDOUT)
+
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 


### PR DESCRIPTION
Simplify the errors that need to be handled by applications and wrap all import errors in our ImportError exception class

We also suppress exceptions if `skip_invalid` is set