### PR TITLE
Clean up temporary files after unzipping and importing

### DIFF
--- a/lib/spatial_features/download.rb
+++ b/lib/spatial_features/download.rb
@@ -3,13 +3,6 @@ require 'open-uri'
 module SpatialFeatures
   module Download
     # file can be a url, path, or file, any of which can return be a zipped archive
-    def self.read(file, unzip: nil, **unzip_options)
-      file = Download.open_each(file, unzip: unzip, **unzip_options).first
-      path = ::File.path(file)
-      return ::File.read(path)
-    end
-
-    # file can be a url, path, or file, any of which can return be a zipped archive
     def self.open(file)
       file = Kernel.open(file)
       file = normalize_file(file) if file.is_a?(StringIO)

--- a/lib/spatial_features/importers/base.rb
+++ b/lib/spatial_features/importers/base.rb
@@ -5,10 +5,11 @@ module SpatialFeatures
     class Base
       attr_reader :errors
 
-      def initialize(data, make_valid: false)
+      def initialize(data, make_valid: false, tmpdir: nil)
         @make_valid = make_valid
         @data = data
         @errors = []
+        @tmpdir = tmpdir
       end
 
       def features

--- a/lib/spatial_features/importers/file.rb
+++ b/lib/spatial_features/importers/file.rb
@@ -8,7 +8,7 @@ module SpatialFeatures
 
       FILE_PATTERNS = [/\.kml$/, /\.shp$/, /\.json$/, /\.geojson$/]
       def self.create_all(data, **options)
-        Download.open_each(data, unzip: FILE_PATTERNS, downcase: true).map do |file|
+        Download.open_each(data, unzip: FILE_PATTERNS, downcase: true, tmpdir: options[:tmpdir]).map do |file|
           new(data, **options, current_file: file)
         end
       rescue Unzip::PathNotFound
@@ -23,7 +23,7 @@ module SpatialFeatures
       # If no `current_file` is passed then we just take the first valid file that we find.
       def initialize(data, *args, current_file: nil, **options)
         begin
-          current_file ||= Download.open_each(data, unzip: FILE_PATTERNS, downcase: true).first
+          current_file ||= Download.open_each(data, unzip: FILE_PATTERNS, downcase: true, tmpdir: options[:tmpdir]).first
         rescue Unzip::PathNotFound
           raise ImportError, INVALID_ARCHIVE
         end

--- a/lib/spatial_features/unzip.rb
+++ b/lib/spatial_features/unzip.rb
@@ -16,21 +16,19 @@ module SpatialFeatures
       return Array(paths)
     end
 
-    def self.extract(file_path, output_dir = Dir.mktmpdir, downcase: false)
+    def self.extract(file_path, tmpdir: nil, downcase: false)
+      tmpdir ||= Dir.mktmpdir
       [].tap do |paths|
         entries(file_path).each do |entry|
           next if entry.name =~ IGNORED_ENTRY_PATHS
           output_filename = entry.name
           output_filename = output_filename.downcase if downcase
-          path = "#{output_dir}/#{output_filename}"
+          path = "#{tmpdir}/#{output_filename}"
           FileUtils.mkdir_p(File.dirname(path))
           entry.extract(path)
           paths << path
         end
       end
-    rescue => e
-      FileUtils.remove_entry(output_dir)
-      raise(e)
     end
 
     def self.names(file_path)

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -136,6 +136,21 @@ describe SpatialFeatures::FeatureImport do
       subject.update_features!
     end
 
+    it 'cleans up temporary files after importing' do
+      subject = new_dummy_class(:parent => FeatureImportMock) do
+        has_spatial_features :import => { :test_files => :File }
+
+        def test_files
+          [shapefile.path]
+        end
+      end.new
+
+      tmpdir = Dir.mktmpdir
+      expect(SpatialFeatures::Unzip).to receive(:extract).with(instance_of(File), :tmpdir => tmpdir, :downcase => true).and_call_original
+      expect(FileUtils).to receive(:remove_entry).with(tmpdir)
+      subject.update_features!(:tmpdir => tmpdir)
+    end
+
     it 'aggregates features if multiple sources are specified within a single importer' do
       single = new_dummy_class(:parent => FeatureImportMock) do
         has_spatial_features :import => { :test_kml => :KMLFile }


### PR DESCRIPTION
When we unzip KMZ and shapefile archives we end up with stray files.

Ideally we would have been able to clean up the unzipped files closer to `Unzip.extract` but we actually need the unzipped files for the entire import flow.  Even after all the KML etc... has been processed we may still need to import images that were extracted from the zip file.  

I also looked into doing something like...


```ruby
importers.each do |importer|
  importer.open_file do
    import_features
    cleanup_temp_files
  end
end
```

But that made working with cache_keys pretty awkward.  Essentially we need to open each file early in the import to generate the cache keys, then decide whether to process them.  Sticking with the current process felt most ergonomic.

So... we manage the tmp dir from within `update_features!` and pass it down.
