### PR TITLE
Switch uniq to distinct

### DIFF
--- a/app/models/abstract_feature.rb
+++ b/app/models/abstract_feature.rb
@@ -69,11 +69,11 @@ class AbstractFeature < ActiveRecord::Base
   end
 
   def self.intersecting(other)
-    join_other_features(other).where('ST_Intersects(features.geom_lowres, other_features.geom_lowres)').uniq
+    join_other_features(other).where('ST_Intersects(features.geom_lowres, other_features.geom_lowres)').distinct
   end
 
   def self.within_distance(other, distance_in_meters)
-    join_other_features(other).where('ST_DWithin(features.geom_lowres, other_features.geom_lowres, ?)', distance_in_meters).uniq
+    join_other_features(other).where('ST_DWithin(features.geom_lowres, other_features.geom_lowres, ?)', distance_in_meters).distinct
   end
 
   def self.invalid(column = 'geog::geometry')

--- a/lib/spatial_features/has_spatial_features.rb
+++ b/lib/spatial_features/has_spatial_features.rb
@@ -13,14 +13,14 @@ module SpatialFeatures
         has_many :features, lambda { extending FeaturesAssociationExtensions }, :as => :spatial_model, :dependent => :delete_all
         has_one :aggregate_feature, lambda { extending FeaturesAssociationExtensions }, :as => :spatial_model, :dependent => :delete
 
-        scope :with_features, lambda { joins(:features).uniq }
+        scope :with_features, lambda { joins(:features).distinct }
         scope :without_features, lambda { joins("LEFT OUTER JOIN features ON features.spatial_model_type = '#{Utils.base_class(name)}' AND features.spatial_model_id = #{table_name}.id").where("features.id IS NULL") }
         scope :include_bounds, lambda { SQLHelpers.append_select(joins(:aggregate_feature), :north, :east, :south, :west) }
         scope :include_area, lambda { SQLHelpers.append_select(joins(:aggregate_feature), :area) }
 
-        scope :with_spatial_cache, lambda {|klass| joins(:spatial_caches).where(:spatial_caches => { :intersection_model_type =>  Utils.class_name_with_ancestors(klass) }).uniq }
+        scope :with_spatial_cache, lambda {|klass| joins(:spatial_caches).where(:spatial_caches => { :intersection_model_type =>  Utils.class_name_with_ancestors(klass) }).distinct }
         scope :without_spatial_cache, lambda {|klass| joins("LEFT OUTER JOIN #{SpatialCache.table_name} ON #{SpatialCache.table_name}.spatial_model_id = #{table_name}.id AND #{SpatialCache.table_name}.spatial_model_type = '#{Utils.base_class(name)}' and intersection_model_type IN ('#{Utils.class_name_with_ancestors(klass).join("','") }')").where("#{SpatialCache.table_name}.spatial_model_id IS NULL") }
-        scope :with_stale_spatial_cache, lambda { joins(:spatial_caches).where("#{table_name}.features_hash != spatial_caches.features_hash").uniq } if has_spatial_features_hash?
+        scope :with_stale_spatial_cache, lambda { joins(:spatial_caches).where("#{table_name}.features_hash != spatial_caches.features_hash").distinct } if has_spatial_features_hash?
 
         has_many :spatial_caches, :as => :spatial_model, :dependent => :delete_all, :class_name => 'SpatialCache'
         has_many :model_a_spatial_proximities, :as => :model_a, :class_name => 'SpatialProximity', :dependent => :delete_all

--- a/lib/spatial_features/venn_polygons.rb
+++ b/lib/spatial_features/venn_polygons.rb
@@ -56,7 +56,7 @@ module SpatialFeatures
     # Instantiate objects to hold the kml and records for each venn polygon
     polygons.group_by{|row| row['kml']}.collect do |kml, rows|
       # Uniq on row id in case a single record had self intersecting multi geometry, which would cause it to appear duplicated on a single venn polygon
-      records = rows.uniq{|row| row.values_at('id', 'type') }.collect{|row| eager_load_hash.fetch(row['type']).detect{|record| record.id == row['id'].to_i } }
+      records = rows.uniq {|row| row.values_at('id', 'type') }.collect{|row| eager_load_hash.fetch(row['type']).detect{|record| record.id == row['id'].to_i } }
       OpenStruct.new(:kml => kml, :records => records)
     end
   end


### PR DESCRIPTION
uniq was renamed to distinct in Rails 5.1. `uniq` no longer returns a Relation.