### PR TITLE
Raise ImportError if KML contains a NetworkLink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,21 +47,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # libgeos and gdal are required and must be installed before `bunddle install`
+      # libgeos and gdal are required and must be installed before `bundle install`
       # NB: if you add libs here that are required for Gem native extensions be sure to clear the
       # bundle cache in `ruby/setup-ruby` so that the gems are re-compiled
       - name: Install GEOS
         run: |
           sudo add-apt-repository ppa:ubuntugis/ppa
           sudo apt-get update
-          sudo apt-get install libpq-dev libgeos-dev libgeos-3.8.0 libproj-dev gdal-bin -y
+          sudo apt-get install libpq-dev libgeos-dev libgeos3.10.2 libproj-dev gdal-bin -y
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 3
+          cache-version: 4
 
       - name: Run tests
         run: bundle exec rspec

--- a/lib/spatial_features/importers/kml.rb
+++ b/lib/spatial_features/importers/kml.rb
@@ -39,6 +39,7 @@ module SpatialFeatures
         @kml_document ||= begin
           doc = Nokogiri::XML(@data)
           raise ImportError, "Invalid KML document (root node was '#{doc.root&.name}')" unless doc.root&.name.to_s.casecmp?('kml')
+          raise ImportError, "NetworkLink elements are not supported" unless doc.search('NetworkLink').empty?
           doc
         end
       end

--- a/spec/fixtures/kml_file_with_network_link.kml
+++ b/spec/fixtures/kml_file_with_network_link.kml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 ogckml22.xsd">
+
+   <Folder>
+  <name>Traplines of British Columbia</name>
+  <open>1</open>
+  <description/>
+  <LookAt>
+   <longitude>-124.2007623466872</longitude>
+   <latitude>54.24685760366558</latitude>
+   <altitude>0</altitude>
+   <heading>0.7179969377242983</heading>
+   <tilt>0</tilt>
+   <range>1651407.948731373</range>
+   <gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+  </LookAt>
+  <Style>
+   <ListStyle>
+    <listItemType>check</listItemType>
+    <bgColor>00ffffff</bgColor>
+    <maxSnippetLines>2</maxSnippetLines>
+   </ListStyle>
+  </Style>
+    <NetworkLink>
+
+        <name>Trapline_Boundaries</name>
+            <LookAt>
+     <longitude>-124.2007623466872</longitude>
+     <latitude>54.24685760366558</latitude>
+     <altitude>0</altitude>
+     <heading>0.7179969377242983</heading>
+     <tilt>0</tilt>
+     <range>1651407.948731373</range>
+     <gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+    </LookAt>
+        <visibility>0</visibility>
+        <snippet></snippet>
+        <description><![CDATA[<img src='https://openmaps.gov.bc.ca/geo/pub/wms?service=wms&version=1.1.1&request=GetLegendGraphic&layer=pub:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP&style=2983_2984&format=image/png'><br>
+    
+    ]]></description>
+
+           <styleUrl>#noDirections</styleUrl>
+        <Style>
+            <ListStyle>
+                <listItemType>check</listItemType>
+                <bgColor>00ffffff</bgColor>
+                <maxSnippetLines>2</maxSnippetLines>
+            </ListStyle>
+        </Style>
+        
+        <Link>
+            <href>https://openmaps.gov.bc.ca/geo/pub/wms?SERVICE=WMS&amp;VERSION=1.1.1&amp;REQUEST=GetMap&amp;SRS=EPSG:4326&amp;LAYERS=pub:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP&amp;STYLES=2983_2984&amp;FORMAT=application/vnd.google-earth.kml+xml&amp;TRANSPARENT=TRUE&amp;maxFeatures=200&amp;format_options=KMATTR:true;KMSCORE:25;MODE:refresh;SUPEROVERLAY:false&amp;</href>
+            <viewRefreshMode>onStop</viewRefreshMode>
+            <viewRefreshTime>2</viewRefreshTime>
+            <viewFormat>bbox=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth]&amp;WIDTH=[horizPixels]&amp;HEIGHT=[vertPixels]</viewFormat>
+        </Link>
+  
+      
+    </NetworkLink>
+    <NetworkLink>
+
+        <name>Trapline_Boundaries_Outlined</name>
+            <LookAt>
+     <longitude>-124.2007623466872</longitude>
+     <latitude>54.24685760366558</latitude>
+     <altitude>0</altitude>
+     <heading>0.7179969377242983</heading>
+     <tilt>0</tilt>
+     <range>1651407.948731373</range>
+     <gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+    </LookAt>
+        <visibility>0</visibility>
+        <snippet></snippet>
+        <description><![CDATA[<img src='https://openmaps.gov.bc.ca/geo/pub/wms?service=wms&version=1.1.1&request=GetLegendGraphic&layer=pub:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP&style=2983&format=image/png'><br>
+    
+    ]]></description>
+
+           <styleUrl>#noDirections</styleUrl>
+        <Style>
+            <ListStyle>
+                <listItemType>check</listItemType>
+                <bgColor>00ffffff</bgColor>
+                <maxSnippetLines>2</maxSnippetLines>
+            </ListStyle>
+        </Style>
+        
+        <Link>
+            <href>https://openmaps.gov.bc.ca/geo/pub/wms?SERVICE=WMS&amp;VERSION=1.1.1&amp;REQUEST=GetMap&amp;SRS=EPSG:4326&amp;LAYERS=pub:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP&amp;STYLES=2983&amp;FORMAT=application/vnd.google-earth.kml+xml&amp;TRANSPARENT=TRUE&amp;maxFeatures=200&amp;format_options=KMATTR:true;KMSCORE:25;MODE:refresh;SUPEROVERLAY:false&amp;</href>
+            <viewRefreshMode>onStop</viewRefreshMode>
+            <viewRefreshTime>2</viewRefreshTime>
+            <viewFormat>bbox=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth]&amp;WIDTH=[horizPixels]&amp;HEIGHT=[vertPixels]</viewFormat>
+        </Link>
+  
+      
+    </NetworkLink>
+    <NetworkLink>
+
+        <name>Trapline_Boundaries_Colour_Filled</name>
+            <LookAt>
+     <longitude>-124.2007623466872</longitude>
+     <latitude>54.24685760366558</latitude>
+     <altitude>0</altitude>
+     <heading>0.7179969377242983</heading>
+     <tilt>0</tilt>
+     <range>1651407.948731373</range>
+     <gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+    </LookAt>
+        <visibility>0</visibility>
+        <snippet></snippet>
+        <description><![CDATA[<img src='https://openmaps.gov.bc.ca/geo/pub/wms?service=wms&version=1.1.1&request=GetLegendGraphic&layer=pub:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP&style=2984&format=image/png'><br>
+    
+    ]]></description>
+
+           <styleUrl>#noDirections</styleUrl>
+        <Style>
+            <ListStyle>
+                <listItemType>check</listItemType>
+                <bgColor>00ffffff</bgColor>
+                <maxSnippetLines>2</maxSnippetLines>
+            </ListStyle>
+        </Style>
+        
+        <Link>
+            <href>https://openmaps.gov.bc.ca/geo/pub/wms?SERVICE=WMS&amp;VERSION=1.1.1&amp;REQUEST=GetMap&amp;SRS=EPSG:4326&amp;LAYERS=pub:WHSE_WILDLIFE_MANAGEMENT.WAA_TRAPLINE_AREAS_SP&amp;STYLES=2984&amp;FORMAT=application/vnd.google-earth.kml+xml&amp;TRANSPARENT=TRUE&amp;maxFeatures=200&amp;format_options=KMATTR:true;KMSCORE:25;MODE:refresh;SUPEROVERLAY:false&amp;</href>
+            <viewRefreshMode>onStop</viewRefreshMode>
+            <viewRefreshTime>2</viewRefreshTime>
+            <viewFormat>bbox=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth]&amp;WIDTH=[horizPixels]&amp;HEIGHT=[vertPixels]</viewFormat>
+        </Link>
+  
+      
+    </NetworkLink>
+</Folder>
+</kml>

--- a/spec/lib/spatial_features/importers/kml_file_spec.rb
+++ b/spec/lib/spatial_features/importers/kml_file_spec.rb
@@ -67,6 +67,15 @@ describe SpatialFeatures::Importers::KMLFile do
     end
   end
 
+  shared_examples_for 'kml importer with unimportable file' do |data|
+    subject { SpatialFeatures::Importers::KMLFile.new(data) }
+
+    describe '#features' do
+      it 'raises an exception' do
+        expect { subject.features }.to raise_exception(SpatialFeatures::ImportError)
+      end
+    end
+  end
 
   context 'when given a path to a KML file' do
     it_behaves_like 'kml importer', kml_file.path
@@ -86,5 +95,9 @@ describe SpatialFeatures::Importers::KMLFile do
 
   context 'when given KMZ file with an invalid placemark' do
     it_behaves_like 'kml importer with an invalid placemark', kml_file_with_invalid_placemark
+  end
+
+  context 'when given KML with a NetworkLink' do
+    it_behaves_like 'kml importer with unimportable file', kml_file_with_network_link
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -18,6 +18,10 @@ def kml_file_with_invalid_placemark
   open_fixture_file("kml_file_with_invalid_placemark.kml")
 end
 
+def kml_file_with_network_link
+  open_fixture_file("kml_file_with_network_link.kml")
+end
+
 def geojson_file
   open_fixture_file("geo.json")
 end


### PR DESCRIPTION
This also contains an update to make CI run again.  Github changed their `ubuntu-latest` image to Ubuntu 22