### PR TITLE
Ensure deterministic SpatialProximity model a/b

### DIFF
--- a/app/models/spatial_proximity.rb
+++ b/app/models/spatial_proximity.rb
@@ -2,10 +2,34 @@ class SpatialProximity < ActiveRecord::Base
   belongs_to :model_a, :polymorphic => true
   belongs_to :model_b, :polymorphic => true
 
-  def self.between(scope_1, scope_2)
-    where <<-SQL.squish
-      (#{SpatialFeatures::Utils.polymorphic_condition(scope_1, 'model_a')} AND #{SpatialFeatures::Utils.polymorphic_condition(scope_2, 'model_b')}) OR
-      (#{SpatialFeatures::Utils.polymorphic_condition(scope_2, 'model_a')} AND #{SpatialFeatures::Utils.polymorphic_condition(scope_1, 'model_b')})
+  def self.between(scope1, scope2)
+    where condition_sql(scope1, scope2, <<~SQL.squish)
+      (#{SpatialFeatures::Utils.polymorphic_condition(scope1, 'model_a')} AND #{SpatialFeatures::Utils.polymorphic_condition(scope2, 'model_b')})
     SQL
+  end
+
+  def self.condition_sql(scope1, scope2, template, pattern_a = 'model_a', pattern_b = 'model_b')
+    scope1_type = SpatialFeatures::Utils.base_class_of(scope1).to_s
+    scope2_type = SpatialFeatures::Utils.base_class_of(scope2).to_s
+
+    if scope1_type < scope2_type
+      template
+    elsif scope1_type > scope2_type
+      template.gsub(pattern_a, 'model_c').gsub(pattern_b, pattern_a).gsub('model_c', pattern_b)
+    else
+      <<~SQL.squish
+        (#{template}) OR (#{template.gsub(pattern_a, 'model_c').gsub(pattern_b, pattern_a).gsub('model_c', pattern_b)})
+      SQL
+    end
+  end
+
+  # Ensure the 'earliest' model is always model a
+  def self.normalize
+    unnormalized
+      .update_all('model_a_type = model_b_type, model_b_type = model_a_type, model_a_id = model_b_id, model_b_id = model_a_id')
+  end
+
+  def self.unnormalized
+    where('model_a_type > model_b_type OR (model_a_type = model_b_type AND model_a_id > model_b_id)')
   end
 end

--- a/lib/spatial_features/caching.rb
+++ b/lib/spatial_features/caching.rb
@@ -84,11 +84,13 @@ module SpatialFeatures
     results.each do |id, distance, area|
       klass_record.id = id
       SpatialProximity.create! do |proximity|
+        # Always make the spatial model earliest type and id be model a so we can optimize queries
+        data = [[Utils.base_class(record).to_s, record.id], [Utils.base_class(klass_record).to_s, klass_record.id]]
+        data.sort!
+
         # Set id and type instead of model to avoid autosaving the klass_record
-        proximity.model_a_id = record.id
-        proximity.model_a_type = Utils.base_class(record)
-        proximity.model_b_id = klass_record.id
-        proximity.model_b_type = Utils.base_class(klass_record)
+        proximity.model_a_type, proximity.model_a_id = data.first
+        proximity.model_b_type, proximity.model_b_id = data.second
         proximity.distance_in_meters = distance
         proximity.intersection_area_in_square_meters = area
       end

--- a/lib/spatial_features/has_spatial_features.rb
+++ b/lib/spatial_features/has_spatial_features.rb
@@ -136,10 +136,8 @@ module SpatialFeatures
       other_class = Utils.base_class_of(other)
       self_class = Utils.base_class_of(self)
 
-      joins <<~SQL
-        INNER JOIN spatial_proximities
-        ON (spatial_proximities.model_a_type = '#{self_class}' AND spatial_proximities.model_a_id = #{table_name}.id AND spatial_proximities.model_b_type = '#{other_class}' AND spatial_proximities.model_b_id IN (#{Utils.id_sql(other)}))
-        OR (spatial_proximities.model_b_type = '#{self_class}' AND spatial_proximities.model_b_id = #{table_name}.id AND spatial_proximities.model_a_type = '#{other_class}' AND spatial_proximities.model_a_id IN (#{Utils.id_sql(other)}))
+      joins "INNER JOIN spatial_proximities ON " + SpatialProximity.condition_sql(self, other, <<~SQL.squish)
+        (spatial_proximities.model_a_type = '#{self_class}' AND spatial_proximities.model_a_id = #{table_name}.id AND spatial_proximities.model_b_type = '#{other_class}' AND spatial_proximities.model_b_id IN (#{Utils.id_sql(other)}))
       SQL
     end
 


### PR DESCRIPTION
When querying for spatial proximities we generally are comparing members of one table against members of another table. However, we don't know which SpatialProximity column the models will end up in, either `model_a` or `model_b`, which means we have to look for both cases.

Instead, we can ensure we know which column each will be stored in by performing a sort at insert time. We can make model a the record with the earliest model name and id (alphanumerically), and therefore determine which columns to query without having to also check for the case where the records were stored in the opposite columns.

The only case that is unaffected is when the comparison models are the same. Though we could also look at the id columns, we're often not specifying a single id, therefore requiring complex SQL in the query instead of a single comparison in Ruby before constructing the query, so we just leave that case unoptimized.

SpatialProximity.normalize can be used to 'flip' the model of rows where the records where not written to the alphanumerically 'correct' column.