### PR TITLE
Raise EmptyImportError when no features are importable

### DIFF
--- a/lib/spatial_features/importers/base.rb
+++ b/lib/spatial_features/importers/base.rb
@@ -56,4 +56,5 @@ module SpatialFeatures
   # EXCEPTIONS
 
   class ImportError < StandardError; end
+  class EmptyImportError < StandardError; end
 end

--- a/spec/fixtures/kml_file_without_features.kml
+++ b/spec/fixtures/kml_file_without_features.kml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>Without Features Test</name>
+	<Folder>
+		<name>Without Features Test</name>
+		<open>1</open>
+	</Folder>
+</Document>
+</kml>

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -257,6 +257,32 @@ describe SpatialFeatures::FeatureImport do
       expect(subject.update_features!(:skip_invalid => true)).to be_nil
     end
 
+    context "when no valid features are found" do
+      it "raises an exception when allow_blank=false" do
+        subject = new_dummy_class(:parent => FeatureImportMock) do
+          has_spatial_features :import => { :test_kml => :KMLFile }
+
+          def test_kml
+            "#{__dir__}/../../../../spec/fixtures/kml_file_without_features.kml"
+          end
+        end.new
+
+        expect { subject.update_features!(:allow_blank => false) }.to raise_error(SpatialFeatures::EmptyImportError)
+      end
+
+      it "does not raise an exception when allow_blank=true" do
+        subject = new_dummy_class(:parent => FeatureImportMock) do
+          has_spatial_features :import => { :test_kml => :KMLFile }
+
+          def test_kml
+            "#{__dir__}/../../../../spec/fixtures/kml_file_without_features.kml"
+          end
+        end.new
+
+        expect(subject.update_features!(:allow_blank => true)).to be_truthy
+      end
+    end
+
     describe 'spatial caching' do
       let(:other_class) { new_dummy_class }
       subject do

--- a/spec/lib/spatial_features/importers/kml_file_spec.rb
+++ b/spec/lib/spatial_features/importers/kml_file_spec.rb
@@ -77,12 +77,26 @@ describe SpatialFeatures::Importers::KMLFile do
     end
   end
 
+  shared_examples_for 'kml importer without any features' do |data|
+    subject { SpatialFeatures::Importers::KMLFile.new(data) }
+
+    describe '#features' do
+      it 'has no valid records' do
+        expect(subject.features.count).to eq(0)
+      end
+    end
+  end
+
   context 'when given a path to a KML file' do
     it_behaves_like 'kml importer', kml_file.path
   end
 
   context 'when given KML file' do
     it_behaves_like 'kml importer', kml_file
+  end
+
+  context 'when given KML file without features' do
+    it_behaves_like 'kml importer without any features', kml_file_without_features
   end
 
   context 'when given KMZ file' do

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -22,6 +22,10 @@ def kml_file_with_network_link
   open_fixture_file("kml_file_with_network_link.kml")
 end
 
+def kml_file_without_features
+  open_fixture_file("kml_file_without_features.kml")
+end
+
 def geojson_file
   open_fixture_file("geo.json")
 end


### PR DESCRIPTION
update_features now takes a new `allow_blank` kwarg that toggles whether an `EmptyImportError` is raised when there are no valid features to import.