### PR TITLE
Strip altitude from KML <coordinates>

### DIFF
--- a/spec/fixtures/kml_file_with_invalid_altitude.kml
+++ b/spec/fixtures/kml_file_with_invalid_altitude.kml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>kml_file_with_invalid_altitude</name>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<color>ffff9572</color>
+		</PolyStyle>
+	</Style>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<color>ffff9572</color>
+		</PolyStyle>
+	</Style>
+	<Folder>
+		<name>Poly folder</name>
+		<open>1</open>
+		<Placemark>
+			<name>Poly 1</name>
+			<description>This is a description</description>
+			<styleUrl>#m_ylw-pushpin</styleUrl>
+			<gx:balloonVisibility>1</gx:balloonVisibility>
+			<Polygon>
+				<tessellate>1</tessellate>
+				<outerBoundaryIs>
+					<LinearRing>
+						<coordinates>
+							-104.2021395645545,60.47065556909579,isNaN -98.5406390057758,60.08348491099549,isNaN -98.40794749318894,63.7611693880032,isNaN -105.6700904293509,63.9562028375275,isNaN -104.2021395645545,60.47065556909579,isNaN
+						</coordinates>
+					</LinearRing>
+				</outerBoundaryIs>
+			</Polygon>
+		</Placemark>
+		<Placemark>
+			<name>Poly 2</name>
+			<description>This is a description also</description>
+			<styleUrl>#msn_ylw-pushpin</styleUrl>
+			<Polygon>
+				<tessellate>1</tessellate>
+				<outerBoundaryIs>
+					<LinearRing>
+						<coordinates>
+							-106.4303166516638,61.16376575099101,isNan -100.7627103394292,61.95514185121152,isNan -100.2655658472707,65.8275552135498,isNan -107.9516815833805,65.21804505333482,isNan -106.4303166516638,61.16376575099101,isNan
+						</coordinates>
+					</LinearRing>
+				</outerBoundaryIs>
+			</Polygon>
+		</Placemark>
+	</Folder>
+</Document>
+</kml>

--- a/spec/lib/spatial_features/importers/kml_file_spec.rb
+++ b/spec/lib/spatial_features/importers/kml_file_spec.rb
@@ -89,6 +89,10 @@ describe SpatialFeatures::Importers::KMLFile do
     it_behaves_like 'kml importer', kmz_file
   end
 
+  context 'when given KML file with invalid altitude' do
+    it_behaves_like 'kml importer', kml_file_with_invalid_altitude
+  end
+
   context 'when given KMZ file with features but no placemarks' do
     it_behaves_like 'kml importer without placemarks', kmz_file_features_without_placemarks
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -22,6 +22,10 @@ def kml_file_with_network_link
   open_fixture_file("kml_file_with_network_link.kml")
 end
 
+def kml_file_with_invalid_altitude
+  open_fixture_file("kml_file_with_invalid_altitude.kml")
+end
+
 def geojson_file
   open_fixture_file("geo.json")
 end


### PR DESCRIPTION
We strip legitimate altitude as well as invalid values like `NaN` in order to be able to call `ST_GeomFromKML`.