### PR TITLE
Improve handling of invalid encodings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 # development dependencies will be added by default to the :development group.
 gemspec
 
+gem 'rgeo-shapefile', :git => "https://github.com/rgeo/rgeo-shapefile.git", :ref => "41b8e7acea0a3abf5bf859baff5d1ff25cbc75ed"
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/lib/spatial_features/has_spatial_features/feature_import.rb
+++ b/lib/spatial_features/has_spatial_features/feature_import.rb
@@ -156,6 +156,4 @@ module SpatialFeatures
   end
 
   ENCODING_ERROR = /invalid byte sequence/i.freeze
-
-  class ImportError < StandardError; end
 end

--- a/lib/spatial_features/has_spatial_features/feature_import.rb
+++ b/lib/spatial_features/has_spatial_features/feature_import.rb
@@ -54,6 +54,10 @@ module SpatialFeatures
       if skip_invalid
         Rails.logger.warn "Error updating #{self.class} #{self.id}. #{e.message}"
         return nil
+      elsif ENCODING_ERROR.match?(e.message)
+        raise ImportEncodingError,
+              "One or more features you are trying to import has text encoded in an un-supported format (#{e.message})",
+              e.backtrace
       else
         raise ImportError, e.message, e.backtrace
       end
@@ -150,6 +154,8 @@ module SpatialFeatures
       has_spatial_features_hash? && cache_key == features_hash
     end
   end
+
+  ENCODING_ERROR = /invalid byte sequence/i.freeze
 
   class ImportError < StandardError; end
 end

--- a/lib/spatial_features/importers/base.rb
+++ b/lib/spatial_features/importers/base.rb
@@ -66,5 +66,6 @@ module SpatialFeatures
   # EXCEPTIONS
 
   class ImportError < StandardError; end
+  class ImportEncodingError < ImportError; end
   class EmptyImportError < ImportError; end
 end

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -104,6 +104,20 @@ describe SpatialFeatures::FeatureImport do
       subject.update_features!
     end
 
+    it 're-raises encoding errors has ImportEncodingError' do
+      allow_any_instance_of(Feature).to receive(:save).and_raise(ArgumentError.new("invalid byte sequence in UTF-8"))
+
+      subject = new_dummy_class(:parent => FeatureImportMock) do
+        has_spatial_features :import => { :test_files => :Shapefile }
+
+        def test_files
+          [shapefile]
+        end
+      end.new
+
+      expect { subject.update_features! }.to raise_error(SpatialFeatures::ImportEncodingError)
+    end
+
     it 'passes multiple kmls from the zipped archive to the kml importer' do
       subject = new_dummy_class(:parent => FeatureImportMock) do
         has_spatial_features :import => { :test_files => :File }


### PR DESCRIPTION
Update this gem to use more-recent rgeo-shapefile including https://github.com/rgeo/rgeo-shapefile/pull/43

Wrap encoding errors in `ImportEncodingError` to make them more ergonomic to rescue from host applications


