### PR TITLE
Make EmptyImportError inherit from ImportError

### DIFF
--- a/lib/spatial_features/importers/base.rb
+++ b/lib/spatial_features/importers/base.rb
@@ -56,5 +56,5 @@ module SpatialFeatures
   # EXCEPTIONS
 
   class ImportError < StandardError; end
-  class EmptyImportError < StandardError; end
+  class EmptyImportError < ImportError; end
 end


### PR DESCRIPTION
More ergonomic and easier to rescue in host apps