### PR TITLE
Improve allow blank

### DIFF
--- a/lib/spatial_features/has_spatial_features/feature_import.rb
+++ b/lib/spatial_features/has_spatial_features/feature_import.rb
@@ -143,7 +143,7 @@ module SpatialFeatures
         raise ImportError, "Error updating #{self.class} #{self.id}. #{errors.to_sentence}"
       end
 
-      return features
+      valid
     end
 
     def features_cache_key_matches?(cache_key)

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -281,6 +281,20 @@ describe SpatialFeatures::FeatureImport do
 
         expect(subject.update_features!(:allow_blank => true)).to be_truthy
       end
+
+      it "does not raise an exception when already persisted and associations are reset during save" do
+        subject = new_dummy_class(:parent => FeatureImportMock) do
+          has_spatial_features :import => { :test_kml => :KMLFile }
+
+          attr_accessor :test_kml
+        end.create
+
+        expect(subject).to be_persisted
+
+        subject.test_kml = fixture_file_path("test.kml")
+        expect(subject.update_features!(:allow_blank => false)).to be_truthy
+        expect(subject.reload.features).not_to be_empty
+      end
     end
 
     describe 'spatial caching' do

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -6,11 +6,11 @@ describe SpatialFeatures::FeatureImport do
     has_spatial_features
 
     def test_kml
-      "#{__dir__}/../../../../spec/fixtures/test.kml"
+      fixture_file_path("test.kml")
     end
 
     def test_kmz
-      "#{__dir__}/../../../../spec/fixtures/test.kmz"
+      fixture_file_path("test.kmz")
     end
   end
 
@@ -188,7 +188,7 @@ describe SpatialFeatures::FeatureImport do
         has_spatial_features :import => { :test_kml => :KMLFile }
 
         def test_kml
-          "#{__dir__}/../../../../spec/fixtures/long_placemark_name.kml"
+          fixture_file_path("long_placemark_name.kml")
         end
       end.new
 
@@ -263,7 +263,7 @@ describe SpatialFeatures::FeatureImport do
           has_spatial_features :import => { :test_kml => :KMLFile }
 
           def test_kml
-            "#{__dir__}/../../../../spec/fixtures/kml_file_without_features.kml"
+            fixture_file_path("kml_file_without_features.kml")
           end
         end.new
 
@@ -275,7 +275,7 @@ describe SpatialFeatures::FeatureImport do
           has_spatial_features :import => { :test_kml => :KMLFile }
 
           def test_kml
-            "#{__dir__}/../../../../spec/fixtures/kml_file_without_features.kml"
+            fixture_file_path("kml_file_without_features.kml")
           end
         end.new
 
@@ -319,7 +319,7 @@ describe SpatialFeatures::FeatureImport do
           has_spatial_features :import => { :test_kml => :KMLFile }, :image_handlers => [:ImageHandlerMock]
 
           def test_kml
-            "#{__dir__}/../../../../spec/fixtures/kmz_with_images.kmz"
+            fixture_file_path("kmz_with_images.kmz")
           end
         end.create
       end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,3 +1,7 @@
+def fixture_file_path(path)
+  "#{SpatialFeatures::Engine.root}/spec/fixtures/#{path}"
+end
+
 def open_fixture_file(path)
   File.open("#{SpatialFeatures::Engine.root}/spec/fixtures/#{path}")
 end


### PR DESCRIPTION
Previously, persisted records would clear their association caches on `save` which made checking `Model#features` unreliable.  Instead we check the valid records detected to determine whether a call to `update_features` resulted in blank results.

This also includes adding a `fixure_file_path` helper to tidy up the specs a bit.