### PR TITLE
Fix Rails 8 deadlock in KML feature import

### DIFF
--- a/lib/spatial_features/importers/kml.rb
+++ b/lib/spatial_features/importers/kml.rb
@@ -56,24 +56,23 @@ module SpatialFeatures
       end
 
       def geom_from_kml(kml)
-        geom = nil
-        conn = nil
-
         strip_altitude(kml)
 
-        # Do query in a new thread so we use a new connection (if the query fails it will poison the transaction of the current connection)
-        #
-        # We manually checkout a new connection since Rails re-uses DB connections across threads.
-        Thread.new do
-          conn = ActiveRecord::Base.connection_pool.checkout
-          geom = conn.select_value("SELECT ST_GeomFromKML(#{conn.quote(kml.to_s)})")
-        rescue ActiveRecord::StatementInvalid => e # Discard Invalid KML features
-          geom = nil
-        ensure
-          ActiveRecord::Base.connection_pool.checkin(conn) if conn
-        end.join
-
-        return geom
+        # Run the parse inside a SAVEPOINT so a `ST_GeomFromKML` failure on a single
+        # invalid feature rolls back only that savepoint, not the surrounding
+        # transaction. The previous implementation spawned a thread and checked out
+        # a fresh connection for the same isolation reason, but on Rails 8 that
+        # pattern deadlocks under `use_transactional_fixtures` — the test pins its
+        # connection, the spawned thread blocks indefinitely waiting on
+        # `ActiveRecord::Base.connection_pool.checkout`. A nested transaction
+        # (`requires_new: true`) gives identical fault containment without crossing
+        # thread boundaries.
+        ActiveRecord::Base.transaction(requires_new: true) do
+          conn = ActiveRecord::Base.connection
+          conn.select_value("SELECT ST_GeomFromKML(#{conn.quote(kml.to_s)})")
+        end
+      rescue ActiveRecord::StatementInvalid # Discard invalid KML features
+        nil
       end
 
       def images_from_metadata(metadata)

--- a/lib/spatial_features/version.rb
+++ b/lib/spatial_features/version.rb
@@ -1,3 +1,3 @@
 module SpatialFeatures
-  VERSION = "3.10.0"
+  VERSION = "3.10.1"
 end


### PR DESCRIPTION
## Summary

`Importers::KML#geom_from_kml` ran each `ST_GeomFromKML` SQL in a freshly-spawned thread, manually checking out a separate connection from `ActiveRecord::Base.connection_pool` for fault isolation: a malformed KML feature would raise `StatementInvalid` on the worker connection, which Postgres aborts; on the test/main connection that abort would poison the surrounding transaction. The thread trick worked on Rails 7.x.

Rails 7.1 introduced per-test connection pinning under `use_transactional_fixtures = true`, and Rails 8.1 made the pin stricter. The spawned worker thread now blocks indefinitely at `ConnectionPool#checkout`, and the main thread blocks on `Thread#join`. Every KMZ-import controller spec hangs forever.

Replace the thread+separate-connection pattern with a `transaction(requires_new: true)` SAVEPOINT on the existing connection. A `StatementInvalid` from a malformed feature rolls back only the savepoint; the surrounding transaction is untouched. Same fault containment, no thread crossing.

The savepoint approach is backwards-compatible to every Rails version this gem supports — `transaction(requires_new: true)` has issued SAVEPOINTs since Rails 3.0.

Bumped patch version to 3.10.1.

## Test plan

- [ ] KMZ-import controller specs in a host running Rails 8.1 + `use_transactional_fixtures` finish in <1s instead of hanging forever
- [ ] Manually upload a KMZ with malformed geometry — outer transaction stays alive, malformed feature is silently skipped (same behaviour as before the fix)
- [ ] Existing spatial_features test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)