### PR TITLE
fix: Clean up temp dirs when `update_features!` creates its own tmpdir

### DIFF
--- a/lib/spatial_features/has_spatial_features/feature_import.rb
+++ b/lib/spatial_features/has_spatial_features/feature_import.rb
@@ -25,7 +25,7 @@ module SpatialFeatures
       tmpdir = options.fetch(:tmpdir) { Dir.mktmpdir("ruby_spatial_features") }
 
       ActiveRecord::Base.transaction do
-        imports = spatial_feature_imports(options[:import], options[:make_valid], options[:tmpdir])
+        imports = spatial_feature_imports(options[:import], options[:make_valid], tmpdir)
         cache_key = Digest::MD5.hexdigest(imports.collect(&:cache_key).join)
 
         return if !force && features_cache_key_matches?(cache_key)

--- a/lib/spatial_features/version.rb
+++ b/lib/spatial_features/version.rb
@@ -1,3 +1,3 @@
 module SpatialFeatures
-  VERSION = "3.10.2"
+  VERSION = "3.10.3"
 end

--- a/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/feature_import_spec.rb
@@ -198,6 +198,31 @@ describe SpatialFeatures::FeatureImport do
       subject.update_features!(:tmpdir => tmpdir)
     end
 
+    it 'cleans up temporary files after importing when no tmpdir is passed' do
+      subject = new_dummy_class(:parent => FeatureImportMock) do
+        has_spatial_features :import => { :test_files => :File }
+
+        def test_files
+          [shapefile.path]
+        end
+      end.new
+
+      expect { subject.update_features! }.not_to change { Dir.glob("#{Dir.tmpdir}/*").select {|path| File.directory?(path) } }
+    end
+
+    it 'cleans up temporary files when the import fails and skip_invalid is true' do
+      subject = new_dummy_class(:parent => FeatureImportMock) do
+        has_spatial_features :import => { :test_files => :File }
+
+        def test_files
+          [shapefile.path]
+        end
+      end.new
+
+      expect(subject).to receive(:import_features).once.and_raise(StandardError)
+      expect { subject.update_features!(:skip_invalid => true) }.not_to change { Dir.glob("#{Dir.tmpdir}/*").select {|path| File.directory?(path) } }
+    end
+
     it 'aggregates features if multiple sources are specified within a single importer' do
       single = new_dummy_class(:parent => FeatureImportMock) do
         has_spatial_features :import => { :test_kml => :KMLFile }


### PR DESCRIPTION
## Problem

`update_features!` has leaked one temp directory per archive import since 2022 (1ecc01a). Line 25 creates a tracked temp dir:

```ruby
tmpdir = options.fetch(:tmpdir) { Dir.mktmpdir("ruby_spatial_features") }
```

but `Hash#fetch` with a block doesn't write the default back into the hash, so line 28 passed `options[:tmpdir]` — still `nil` — down to the importers. `Unzip.extract` then minted its own untracked temp dir for every KMZ / zipped-shapefile import, and the `ensure` block only removed the empty tracked dir (a decoy).

Bulk runs amplify this: a nightly `update_features!` sweep over thousands of records with `skip_invalid: true` never aborts and leaks thousands of extraction directories per run. This is what got Stolo's nightly `update_geometry` cron disabled in Nov 2024.

## Fix

Pass the local `tmpdir` to `spatial_feature_imports` instead of `options[:tmpdir]`, so extraction happens inside the tracked directory the existing `ensure` already removes. One line.

## Tests

The existing cleanup spec only covered the caller-supplied-`tmpdir` path (where `options[:tmpdir]` *is* set), which is why the default path went untested for four years. Added two regression specs for the no-`tmpdir` path — import success and import failure under `skip_invalid: true` (unzip happens before the failure, so this is exactly the leak scenario). Both fail against the old code and pass with the fix. Full suite: 248 examples, 0 failures.

## Not addressed (known, much smaller drips)

- `Download.normalize_file` uses blockless `Tempfile.new` (GC-finalizer cleanup only)
- `Shapefile#project_to_4326` leaks the ogr2ogr companion files (`.dbf`/`.shx`/`.prj`/`.cpg`) — the `ensure` deletes only the `.shp`

Both are plain files (not directories), so age-based /tmp sweeps reclaim them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)