### PR TITLE
Add a way to retry imports that previously failed

### DIFF
--- a/lib/spatial_features/has_spatial_features/queued_spatial_processing.rb
+++ b/lib/spatial_features/has_spatial_features/queued_spatial_processing.rb
@@ -3,6 +3,28 @@ module SpatialFeatures
     extend ActiveSupport::Concern
     mattr_accessor :priority_offset, default: 0 # Offsets the queued priority of spatial tasks. Lower numbers run with higher priority
 
+    class_methods do
+      # Records whose most recent feature import failed. `->>` yields NULL for a missing
+      # key, so a record that has never been imported is not included.
+      def with_failed_feature_updates
+        where("spatial_processing_status_cache->>'update_features!' = 'failure'")
+      end
+
+      # Re-import everything whose last attempt failed. Nothing else retries these, so a
+      # record broken by a defect stays broken after the defect is fixed unless something
+      # sweeps it up.
+      #
+      # Queued rather than run inline, so a caller (a deploy migration, a console) doesn't
+      # block on reimporting shapefiles, and so `SpatialProcessingJob`'s callbacks maintain
+      # `spatial_processing_status_cache` — calling `#update_features!` directly bypasses
+      # them and leaves a record flagged as failed even when the retry succeeded.
+      def retry_failed_feature_updates!(**options)
+        with_failed_feature_updates.find_each do |record|
+          record.delay_update_features!(**options)
+        end
+      end
+    end
+
     def self.update_cached_status(record, method_name, state)
       return unless record.has_attribute?(:spatial_processing_status_cache)
 

--- a/lib/spatial_features/version.rb
+++ b/lib/spatial_features/version.rb
@@ -1,3 +1,3 @@
 module SpatialFeatures
-  VERSION = "3.11.0"
+  VERSION = "3.11.1"
 end

--- a/spec/lib/spatial_features/has_spatial_features/queued_spatial_processing_spec.rb
+++ b/spec/lib/spatial_features/has_spatial_features/queued_spatial_processing_spec.rb
@@ -43,6 +43,37 @@ describe SpatialFeatures::QueuedSpatialProcessing do
     end
   end
 
+  describe '::retry_failed_feature_updates!', delayed_job: false do
+    let(:klass) { new_dummy_class(:spatial_processing_status_cache => :jsonb) }
+
+    def status!(record, state)
+      SpatialFeatures::QueuedSpatialProcessing.update_cached_status(record, 'update_features!', state)
+    end
+
+    it 'queues a feature update for each record whose last import failed' do
+      failed = klass.create.tap {|record| status!(record, 'failure') }
+
+      expect { klass.retry_failed_feature_updates! }
+        .to change { failed.spatial_processing_jobs('update_features!').count }
+        .by(1)
+    end
+
+    it 'ignores records that succeeded, and records never imported at all' do
+      klass.create.tap {|record| status!(record, 'success') }
+      klass.create # no import attempted, so no key in the cache at all
+
+      expect { klass.retry_failed_feature_updates! }.not_to change { Delayed::Job.count }
+    end
+
+    it 'passes options through to the queued job' do
+      klass.create.tap {|record| status!(record, 'failure') }
+
+      klass.retry_failed_feature_updates!(:priority => 10)
+
+      expect(Delayed::Job.last.priority).to eq(10)
+    end
+  end
+
   describe '#clear_feature_update_error_status' do
     let(:klass) { new_dummy_class(:spatial_processing_status_cache => :jsonb) }
 


### PR DESCRIPTION
Follow-up to [#57](https://github.com/culturecode/spatial_features/pull/57), prompted by review of the host-side sweep in [stolo_connect#1964](https://github.com/culturecode/stolo_connect/pull/1964): *"Is there no mechanism in spatial_features or connect_engine that does this for us? This seems like a lot to reimplement to do something that should probably just be a single method call."*

There wasn't, and the reviewer is right that there should be. `FeatureImport::ClassMethods#update_features!` covers bulk re-import, but nothing selects the records whose last attempt failed, and nothing queues the retry. So every host that wants to sweep them up writes the same three things by hand:

- the jsonb predicate for the failure status
- the iteration
- the choice to queue rather than run inline

The third is the one that bites. Calling `#update_features!` directly bypasses the `SpatialProcessingJob` callbacks that maintain `spatial_processing_status_cache`, so a record that imports successfully stays flagged as failed — and is picked up again by the next sweep. That was a real bug in the host-side task before this.

`::with_failed_feature_updates` and `::retry_failed_feature_updates!` put all three in the gem that owns the status cache. Options pass through to the queued job, so a caller can lower the priority to keep a large sweep behind live uploads:

```ruby
ReferralSubmission.retry_failed_feature_updates!(priority: 10)
```

## Why here rather than Connect Engine

`referrals` and `sites` both carry `spatial_processing_status_cache` without including the engine's `SpatialFeaturesDefaults` concern, so anything defined there would silently miss them. The gem is where `has_spatial_features` and the status cache live, so every spatial model gets it regardless of which concern the host mixed in.

## Verification

`bundle exec rspec` — 266 examples, 0 failures (19 pending, pre-existing). Three new examples cover the failure-only selection, that successes and never-imported records are left alone, and that options reach the queued job.

## Deploying

3.11.1 — additive, no behaviour change to existing calls. `connect_engine`'s `~> 3.11` constraint already admits it, so only the locks move.

Refs https://github.com/culturecode/stolo_connect/issues/1962